### PR TITLE
Add #EOQ# tag to Yago2 queries

### DIFF
--- a/queries/individual/yago2/string/1.q
+++ b/queries/individual/yago2/string/1.q
@@ -1,7 +1,8 @@
 SELECT ?GivenName ?FamilyName WHERE{
-    ?p <http://yago-knowledge.org/resource/hasGivenName> ?GivenName . 
-    ?p <http://yago-knowledge.org/resource/hasFamilyName> ?FamilyName . 
-    ?p <http://yago-knowledge.org/resource/wasBornIn> ?city . 
+    ?p <http://yago-knowledge.org/resource/hasGivenName> ?GivenName .
+    ?p <http://yago-knowledge.org/resource/hasFamilyName> ?FamilyName .
+    ?p <http://yago-knowledge.org/resource/wasBornIn> ?city .
     ?p <http://yago-knowledge.org/resource/hasAcademicAdvisor> ?a .
     ?a <http://yago-knowledge.org/resource/wasBornIn> ?city .
 }
+#EOQ#

--- a/queries/individual/yago2/string/2.q
+++ b/queries/individual/yago2/string/2.q
@@ -1,9 +1,10 @@
 SELECT ?GivenName ?FamilyName WHERE{
-    ?p <http://yago-knowledge.org/resource/hasGivenName> ?GivenName . 
-    ?p <http://yago-knowledge.org/resource/hasFamilyName> ?FamilyName . 
-    ?p <http://yago-knowledge.org/resource/wasBornIn> ?city . 
+    ?p <http://yago-knowledge.org/resource/hasGivenName> ?GivenName .
+    ?p <http://yago-knowledge.org/resource/hasFamilyName> ?FamilyName .
+    ?p <http://yago-knowledge.org/resource/wasBornIn> ?city .
     ?p <http://yago-knowledge.org/resource/hasAcademicAdvisor> ?a .
     ?a <http://yago-knowledge.org/resource/wasBornIn> ?city .
     ?p <http://yago-knowledge.org/resource/isMarriedTo> ?p2 .
     ?p2 <http://yago-knowledge.org/resource/wasBornIn> ?city .
 }
+#EOQ#

--- a/queries/individual/yago2/string/3.q
+++ b/queries/individual/yago2/string/3.q
@@ -1,6 +1,7 @@
 SELECT ?name1 ?name2 WHERE{
-    ?a1 <http://yago-knowledge.org/resource/hasPreferredName> ?name1 . 
+    ?a1 <http://yago-knowledge.org/resource/hasPreferredName> ?name1 .
     ?a2 <http://yago-knowledge.org/resource/hasPreferredName> ?name2 .
     ?a1 <http://yago-knowledge.org/resource/actedIn> ?movie .
     ?a2 <http://yago-knowledge.org/resource/actedIn> ?movie .
 }
+#EOQ#

--- a/queries/individual/yago2/string/4.q
+++ b/queries/individual/yago2/string/4.q
@@ -5,3 +5,4 @@ SELECT ?name1 ?name2 WHERE{
     ?p1 <http://yago-knowledge.org/resource/wasBornIn> ?city .
     ?p2 <http://yago-knowledge.org/resource/wasBornIn> ?city .
 }
+#EOQ#


### PR DESCRIPTION
Fix for Yago2 queries where they are not dictionary encoded unless the #EOQ# tag is specified